### PR TITLE
Update srcmapr-reverse socket

### DIFF
--- a/iml-srcmap-reverse.socket
+++ b/iml-srcmap-reverse.socket
@@ -8,4 +8,4 @@ ListenStream=/var/run/iml-srcmap-reverse.sock
 RemoveOnStop=true
 
 [Install]
-WantedBy=sockets.target
+WantedBy=iml-manager.target


### PR DESCRIPTION
The socket is currently wanted by sockets.target. This causes an ordering issue when loading the iml-manager.target.
Instead, it should be wanted by iml-manager.target.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>